### PR TITLE
fix build with xcode 16 / gcc 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -514,7 +514,7 @@ ifeq ($(WINDOWS_BUILD),1) # fixes compilation in MXE on Linux and WSL
   OBJCOPY := objcopy
   OBJDUMP := $(CROSS)objdump
 else ifeq ($(OSX_BUILD),1)
-  CPP := cpp-12 -P
+  CPP := cpp-14 -P
   OBJDUMP := i686-w64-mingw32-objdump
   OBJCOPY := i686-w64-mingw32-objcopy
 else # Linux & other builds

--- a/src/pc/gfx/gfx_opengl.c
+++ b/src/pc/gfx/gfx_opengl.c
@@ -537,7 +537,7 @@ static void gfx_opengl_select_texture(int tile, GLuint texture_id) {
      gfx_opengl_set_texture_uniforms(opengl_prg, tile);
 }
 
-static void gfx_opengl_upload_texture(uint8_t *rgba32_buf, int width, int height) {
+static void gfx_opengl_upload_texture(const uint8_t *rgba32_buf, int width, int height) {
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba32_buf);
     opengl_tex[opengl_curtex]->size[0] = width;
     opengl_tex[opengl_curtex]->size[1] = height;


### PR DESCRIPTION
This PR fixes compilation with the latest Xcode (16.1 at the time of writing) and GCC 14, which brings the project up to the latest toolchain. Game tested as fully working on the latest iOS.
![sm64ios](https://github.com/user-attachments/assets/9eece2f1-c42f-4a55-9255-6e437e81f8fa)
